### PR TITLE
Add filetype metadata for resource uploads

### DIFF
--- a/application/controllers/AdminCoursesController.php
+++ b/application/controllers/AdminCoursesController.php
@@ -383,7 +383,8 @@ class AdminCoursesController extends CI_Controller
                     'duration' => $file['playtime_string'],
                     'width' => $file['video']['resolution_x'],
                     'height' => $file['video']['resolution_y'],
-                    'filesize' => $file['filesize']
+                    'filesize' => $file['filesize'],
+                    'filetype' => $fileExtension,
                 ];
             } else {
                 // Handle cases where video data is missing
@@ -398,6 +399,7 @@ class AdminCoursesController extends CI_Controller
             if (isset($file['filesize'])) {
                 return [
                     'filesize' => $file['filesize'],
+                    'filetype' => $fileExtension,
                     'message' => 'PDF file uploaded successfully.'
                 ];
             } else {

--- a/application/controllers/StudentCoursesController.php
+++ b/application/controllers/StudentCoursesController.php
@@ -351,6 +351,7 @@ class StudentCoursesController extends CI_Controller
                     'course_id' => $course_id,
                     'file_size' => $fileDetails['filesize'],
                     'path' => $fileData['file_name'],
+                    'resource_type' => $fileDetails['filetype'],
                 ];
 
                 // Insert into 'uploads' table
@@ -364,6 +365,7 @@ class StudentCoursesController extends CI_Controller
                     'path' => base_url('uploads/resources/' . $fileData['file_name']),
                     'thumbnail' => base_url('uploads/resources/' . $fileData['file_name']), // Placeholder thumbnail
                     'duration' => isset($fileDetails['duration']) ? $fileDetails['duration'] : null, // Video duration or null for PDFs
+                    'filetype' => $fileDetails['filetype'],
                     'description' => 'Uploaded successfully'
                 ];
             } else {
@@ -396,7 +398,8 @@ class StudentCoursesController extends CI_Controller
                     'duration' => $file['playtime_string'],
                     'width' => $file['video']['resolution_x'],
                     'height' => $file['video']['resolution_y'],
-                    'filesize' => $file['filesize']
+                    'filesize' => $file['filesize'],
+                    'filetype' => $fileExtension,
                 ];
             } else {
                 // Handle cases where video data is missing
@@ -411,6 +414,7 @@ class StudentCoursesController extends CI_Controller
             if (isset($file['filesize'])) {
                 return [
                     'filesize' => $file['filesize'],
+                    'filetype' => $fileExtension,
                     'message' => 'PDF file uploaded successfully.'
                 ];
             } else {


### PR DESCRIPTION
## Summary
- include `filetype` field when detecting video/PDF details in Admin and Student controllers
- store `resource_type` when students upload resources
- return `filetype` with uploaded resource info

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68572434a920832ca5e5b84435fe043d