### PR TITLE
Fix save_quiz lesson id usage

### DIFF
--- a/application/controllers/AdminCoursesController.php
+++ b/application/controllers/AdminCoursesController.php
@@ -463,6 +463,7 @@ class AdminCoursesController extends CI_Controller
         $quiz_title = $this->input->post('quiz_title');
         $questions = json_decode($this->input->post('questions'), true);
         $quiz_id = $this->input->post('quiz_id'); // Assuming quiz_id is sent from the frontend if it's an update
+        $lesson_id = $this->input->post('lesson_id');
 
         // Start transaction to ensure atomicity
         $this->db->trans_start();
@@ -472,7 +473,7 @@ class AdminCoursesController extends CI_Controller
             // Update quiz details
             $quiz_data = [
                 'quiz_title' => $quiz_title,
-                'lesson_id' => 1,
+                'lesson_id' => $lesson_id,
                 'updatedAt' => date('Y-m-d H:i:s'),
             ];
             $this->db->where('id', $quiz_id);
@@ -491,7 +492,7 @@ class AdminCoursesController extends CI_Controller
             // Insert quiz details if it's a new quiz
             $quiz_data = [
                 'quiz_title' => $quiz_title,
-                'lesson_id' => 1,
+                'lesson_id' => $lesson_id,
                 'createdAt' => date('Y-m-d H:i:s'),
             ];
             $this->db->insert('quizzes', $quiz_data);

--- a/application/controllers/CoursesController.php
+++ b/application/controllers/CoursesController.php
@@ -333,7 +333,7 @@ class CoursesController extends CI_Controller
             // Insert quiz details if it's a new quiz
             $quiz_data = [
                 'quiz_title' => $quiz_title,
-                'lesson_id' => 1,
+                'lesson_id' => $lesson_id,
                 'course_id' => $course_id,
                 'createdAt' => date('Y-m-d H:i:s'),
             ];

--- a/application/controllers/StudentCoursesController.php
+++ b/application/controllers/StudentCoursesController.php
@@ -476,6 +476,7 @@ class StudentCoursesController extends CI_Controller
         $quiz_title = $this->input->post('quiz_title');
         $questions = json_decode($this->input->post('questions'), true);
         $quiz_id = $this->input->post('quiz_id'); // Assuming quiz_id is sent from the frontend if it's an update
+        $lesson_id = $this->input->post('lesson_id');
 
         // Start transaction to ensure atomicity
         $this->db->trans_start();
@@ -485,7 +486,7 @@ class StudentCoursesController extends CI_Controller
             // Update quiz details
             $quiz_data = [
                 'quiz_title' => $quiz_title,
-                'lesson_id' => 1,
+                'lesson_id' => $lesson_id,
                 'updatedAt' => date('Y-m-d H:i:s'),
             ];
             $this->db->where('id', $quiz_id);
@@ -504,7 +505,7 @@ class StudentCoursesController extends CI_Controller
             // Insert quiz details if it's a new quiz
             $quiz_data = [
                 'quiz_title' => $quiz_title,
-                'lesson_id' => 1,
+                'lesson_id' => $lesson_id,
                 'createdAt' => date('Y-m-d H:i:s'),
             ];
             $this->db->insert('quizzes', $quiz_data);


### PR DESCRIPTION
## Summary
- load `lesson_id` from POST data in save_quiz endpoints
- use provided lesson id when inserting or updating quizzes

## Testing
- `npm test` *(fails: no test specified)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857244bacf8832ca688d9d8080036ad