### PR TITLE
Fix resource deletion

### DIFF
--- a/application/controllers/AdminCoursesController.php
+++ b/application/controllers/AdminCoursesController.php
@@ -442,15 +442,15 @@ class AdminCoursesController extends CI_Controller
 
     public function deleteVideo()
     {
-        $fileId = $this->input->post('upload_id');
-        $file = $this->common_model->select_where_return_row('*', 'uploads', array('upload_id' => $fileId));
+        $resourceId = $this->input->post('resource_id');
+        $resource   = $this->common_model->select_where_return_row('*', 'resources', array('resource_id' => $resourceId));
 
         // Construct the absolute server path for the file
-        $filePath = FCPATH . 'uploads/videos/' . $file->file_path;
+        $filePath = FCPATH . 'uploads/resources/' . $resource->path;
 
-        if ($file && file_exists($filePath)) {
+        if ($resource && file_exists($filePath)) {
             unlink($filePath); // Delete the file from the server
-            $this->common_model->delete_where(array('upload_id' => $fileId), 'uploads');
+            $this->common_model->delete_where(array('resource_id' => $resourceId), 'resources');
 
             echo json_encode(['success' => true]);
         } else {

--- a/application/controllers/StudentCoursesController.php
+++ b/application/controllers/StudentCoursesController.php
@@ -455,15 +455,15 @@ class StudentCoursesController extends CI_Controller
 
     public function deleteVideo()
     {
-        $fileId = $this->input->post('upload_id');
-        $file = $this->common_model->select_where_return_row('*', 'uploads', array('upload_id' => $fileId));
+        $resourceId = $this->input->post('resource_id');
+        $resource   = $this->common_model->select_where_return_row('*', 'resources', array('resource_id' => $resourceId));
 
         // Construct the absolute server path for the file
-        $filePath = FCPATH . 'uploads/videos/' . $file->file_path;
+        $filePath = FCPATH . 'uploads/resources/' . $resource->path;
 
-        if ($file && file_exists($filePath)) {
+        if ($resource && file_exists($filePath)) {
             unlink($filePath); // Delete the file from the server
-            $this->common_model->delete_where(array('upload_id' => $fileId), 'uploads');
+            $this->common_model->delete_where(array('resource_id' => $resourceId), 'resources');
 
             echo json_encode(['success' => true]);
         } else {


### PR DESCRIPTION
## Summary
- adjust `deleteVideo` to use `resource_id` in admin and student controllers

## Testing
- `npm test` *(fails: Error: no test specified)*
- `composer run-script test:coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857243de8b4832c9e3c7c1f224d6d3a